### PR TITLE
Simplify node usage: add "main" entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "overloadjs",
 	"description": "overload functions depending on the type using a multimethod",
+	"main": "source/overload.js",
 	"keywords": ["overload", "multimethod"],
 	"author": {
 		"name": "Marius Gundersen",


### PR DESCRIPTION
### test.js

```
if (require('overloadjs')) console.log('OK');
```
### before

```
$ node test.js
module.js:338
    throw err;
          ^
Error: Cannot find module 'overloadjs'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (test.js:1:67)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
```
### after

```
$ node test.js
OK
```
